### PR TITLE
updated SweetAlert2 to version 5.2.x and reworked swal_open method to…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
   ],
   "dependencies": {
     "angular": ">=1.3.0",
-    "sweetalert2": "4.1.*"
+    "sweetalert2": "5.2.*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swangular",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "An AngularJS wrapper for Sweet Alert 2",
   "main": "swangular.js",
   "scripts": {
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/skeymeulen/swangular#readme",
   "dependencies": {
     "angular": ">=1.3.0",
-    "sweetalert2": "4.1.*"
+    "sweetalert2": "5.2.*"
   }
 }

--- a/swangular.js
+++ b/swangular.js
@@ -91,50 +91,47 @@ angular.module('swangular', [])
                 locals: $q.all(resolve)
             }).then(function(setup){
 
-                var html = setup.html,
-                    locals = setup.locals;
-                
-                if(options.scope) {
+                var scope = options.scope,
+                    controller = options.controller,
+                    controllerAsOption = options.controllerAs,
+                    preConfirm = options.preConfirm;
 
-                    options.html = $compile(html)(options.scope);
-
-                } else if(options.controller){
-                    
-                    var controllerAs,
-                        scope = $rootScope.$new();
-
-                    if (options.controllerAs && angular.isString(options.controllerAs)) {
-                        controllerAs = options.controllerAs;
-                    }
-
-                    var controllerInstance = $controller(options.controller, angular.extend(
-                        locals,
-                        {
-                            $scope: scope
-                        }), true, controllerAs);
-
-                    var $content = angular.element(html);
-                    $content.data('$ngControllerController', controllerInstance());
-
-                    var compiledElement = $compile($content)(scope);
-                    
-                    if(typeof options.preConfirm === 'string'){
-                        
-                        options.preConfirm = compiledElement.controller()[options.preConfirm];
-                    }
-
-                    options.html = compiledElement;
-
-                }
-
-                // Clean options object before passing it to SweetAlert2
+                delete options.html;
                 delete options.htmlTemplate;
-                delete options.controller;
-                delete options.controllerAs;
                 delete options.resolve;
                 delete options.scope;
+                delete options.controller;
+                delete options.controllerAs;
+                delete options.preConfirm;
 
-                return swal(options);
+                var locals = setup.locals;
+
+                options.html = setup.html;
+
+                if (controller){
+                  var controllerAs;
+                  scope = $rootScope.$new();
+
+                  if (controllerAsOption && angular.isString(controllerAsOption)) {
+                      controllerAs = controllerAsOption;
+                  }
+
+                  var controllerInstance = $controller(controller, angular.extend(
+                      locals,
+                      {
+                          $scope: scope
+                      }), true, controllerAs);
+
+                      if(typeof preConfirm === 'string'){
+                          options.preConfirm = controllerInstance()[preConfirm];
+                      }
+                }
+                var prom = swal(options);
+                var html = document.getElementsByClassName('swal2-modal')[0];
+
+                $compile(html)(scope);
+
+                return prom;
 
             });
 


### PR DESCRIPTION
… compile the html after swal call to bypass cloneNode in new SweetAlert2 versions