### PR TITLE
Fix possibly unhandled rejection errors

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -1,6 +1,6 @@
 var app = angular.module('swangularApp', ['swangular']);
 
-app.controller('AppCtrl', ['$scope', 'swangular', function ($scope, swangular) {
+app.controller('AppCtrl', ['$scope', '$q', 'swangular', function ($scope, $q, swangular) {
 
     var vm = this;
 
@@ -8,21 +8,21 @@ app.controller('AppCtrl', ['$scope', 'swangular', function ($scope, swangular) {
     vm.preConfirmContent = "Default";
 
     vm.preConfirm = function () {
-        return new Promise(function(resolve) {
+        return new $q(function(resolve, reject) {
             vm.preConfirmContent = "This string was injected by preConfirm";
             resolve();
         })
     };
 
     vm.openModal1 = function () {
-        swangular.swal("Title", "Content");
+        swangular.swal("Title", "Content").catch(angular.noop);
     };
 
     vm.openModal2 = function () {
         swangular.open({
             title: "Template test",
             htmlTemplate: "template1.html"
-        })
+        }).catch(angular.noop);
     };
 
     vm.openModal3 = function () {
@@ -31,22 +31,20 @@ app.controller('AppCtrl', ['$scope', 'swangular', function ($scope, swangular) {
             htmlTemplate: "template2.html",
             controller: 'ModalCtrl',
             controllerAs: 'vm'
-        })
+        }).catch(angular.noop);
     };
 
     vm.openModal4 = function () {
-
         $scope.content = 'This string was injected from scope';
 
         swangular.open({
             title: "Template test",
             htmlTemplate: "template3.html",
             scope: $scope
-        })
+        }).catch(angular.noop);
     };
 
     vm.openModal5 = function () {
-
         swangular.open({
             title: "Template test",
             htmlTemplate: "template2.html",
@@ -57,33 +55,30 @@ app.controller('AppCtrl', ['$scope', 'swangular', function ($scope, swangular) {
                     return { content: 'This is resolved content'}
                 }
             }
-        })
+        }).catch(angular.noop);
     };
 
     vm.openModal6 = function () {
-
         swangular.open({
             title: "Pre-confirm test",
             htmlTemplate: "template2.html",
             controller: 'ModalCtrl',
             controllerAs: 'vm',
             preConfirm: vm.preConfirm
-        })
+        }).catch(angular.noop);
     };
 
     vm.openModal7 = function () {
-
         swangular.open({
             title: "Pre-confirm test",
             htmlTemplate: "template2.html",
             controller: 'ModalCtrl',
             controllerAs: 'vm',
             preConfirm: "preConfirm"
-        })
+        }).catch(angular.noop);
     };
 
     vm.openModal8 = function () {
-
         $scope.content = 'This string was injected from scope';
 
         swangular.open({
@@ -91,12 +86,12 @@ app.controller('AppCtrl', ['$scope', 'swangular', function ($scope, swangular) {
             preConfirm: vm.preConfirm,
             htmlTemplate: '/components/network-container/newServerNetworks/new_server_networks.html',
             scope: $scope
-        })
+        }).catch(angular.noop);
     };
 
 }]);
 
-app.controller('ModalCtrl', function () {
+app.controller('ModalCtrl', ['$q', function ($q) {
 
     var vm = this;
 
@@ -104,13 +99,13 @@ app.controller('ModalCtrl', function () {
     vm.modalPreConfirmContent = "";
 
     vm.preConfirm = function () {
-        return new Promise(function(resolve) {
+        return new $q(function(resolve, reject) {
             vm.modalPreConfirmContent = "This string was injected by preConfirm";
             resolve();
-        })
-    }
+        });
+    };
     
-});
+}]);
 
 app.controller('ResolveCtrl', [ 'resolve', function (resolve) {
 
@@ -127,14 +122,13 @@ app.controller('ParentCtrl', ['$scope', 'swangular', function ($scope, swangular
     vm.content = "This string was injected from parent controller";
 
     vm.openModal9 = function () {
-
         swangular.open({
             title: "ParentCtrl Modal",
             htmlTemplate: 'template4.html',
             controller: 'ModalCtrl',
             controllerAs: 'child',
             scope: $scope
-        })
+        }).catch(angular.noop);
     };
 
 }]);


### PR DESCRIPTION
Fixed `Possibly unhandled rejection` errors when the preConfirm methods are called.
Also fixed  `Argument 'scope' is required` error thrown for modals without a controller.
Made sure swal returns a $q promise.